### PR TITLE
Add product-manager-skills to Product Management tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -474,6 +474,7 @@ A product manager is a professional role that is responsible for the development
 - [Notion](https://www.notion.so/?from=awesome-product-manager&utm_source=awesome-product-manager)
 - [Fibery](https://fibery.io/?from=awesome-product-manager&utm_source=awesome-product-manager)
 - [PM-Skills](https://github.com/product-on-purpose/pm-skills?from=awesome-product-manager&utm_source=awesome-product-manager) - A library of 24 plug-and-play product management agent skills for Claude, following the agentskills.io specification.
+- [product-manager-skills](https://github.com/Digidai/product-manager-skills?from=awesome-product-manager&utm_source=awesome-product-manager) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks. Covers discovery, strategy, delivery, SaaS metrics, career coaching, and AI product craft.
 
 #### Customer Journey Map
 


### PR DESCRIPTION
## Summary

- Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) by Digidai to the **Product Management** subsection under Tools.
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft.
- Pure Markdown, zero scripts, zero dependencies. Free and open source.
- Follows the existing list format (`- [Name](URL) - Description`).